### PR TITLE
fixed multiple parameter query issue

### DIFF
--- a/android/src/main/java/sk/fourq/calllog/CallLogPlugin.java
+++ b/android/src/main/java/sk/fourq/calllog/CallLogPlugin.java
@@ -190,7 +190,7 @@ public class CallLogPlugin implements FlutterPlugin, ActivityAware, MethodCallHa
                 generatePredicate(predicates, CallLog.Calls.CACHED_MATCHED_NUMBER, OPERATOR_LIKE, number);
                 generatePredicate(predicates, CallLog.Calls.PHONE_ACCOUNT_ID, OPERATOR_LIKE, number);
                 generatePredicate(predicates, CallLog.Calls.TYPE, OPERATOR_EQUALS, type);
-                queryLogs(StringUtils.join(predicates, "AND"));
+                queryLogs(StringUtils.join(predicates, " AND "));
                 break;
             default:
                 result.notImplemented();


### PR DESCRIPTION
fix #26 

The issue was that when creating query to fetch logs the 'AND' keyword was added incorrectly between query parameters. And the parameter joined with the 'AND' keyword resulted in this syntax error.


Expected Result:
 Statement: 
 `CallLog.query(dateTimeFrom: from, type: CallType.incoming);`
 
 Query generated: 
 `SELECT formatted_number, number, type, date, duration, name, numbertype, numberlabel, matched_number, subscription_id FROM calls WHERE ((date > '1634065200000'AND type = '1') AND ((type != 4)) AND ((phone_account_hidden = 0)) AND ((mark_deleted = 0)) AND (type != 10)) ORDER BY date DESC, null, null)`
 
Actual Result:
 Statement: 
 `CallLog.query(dateTimeFrom: from, type: CallType.incoming);`
 
 Query generated: 
 `SELECT formatted_number, number, type, date, duration, name, numbertype, numberlabel, matched_number, subscription_id FROM calls WHERE ((date > '1634065200000'ANDtype = '1') AND ((type != 4)) AND ((phone_account_hidden = 0)) AND ((mark_deleted = 0)) AND (type != 10)) ORDER BY date DESC, null, null)`
 
 